### PR TITLE
Add contact and education details to resume builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,16 @@
 <section id="data-entry">
 <h2>Sections</h2>
 <div>
+    <h3>Contact Info</h3>
+    <input id="contactName" placeholder="Name" size="15">
+    <input id="contactEmail" placeholder="Email" size="20">
+    <input id="contactPhone" placeholder="Phone" size="15">
+    <input id="contactWebsite" placeholder="Website" size="20">
+    <input id="contactGithub" placeholder="GitHub" size="20">
+    <button onclick="saveContact()">Save</button>
+</div>
+
+<div>
     <h3>Add Summary</h3>
     <input id="summaryText" placeholder="Summary text" size="50">
     <button onclick="addSummary()">Add</button>
@@ -44,6 +54,15 @@
     <br>
     <button onclick="addProject()">Add</button>
     <ul id="projectList"></ul>
+</div>
+
+<div>
+    <h3>Add Education</h3>
+    <input id="eduSchool" placeholder="School" size="20">
+    <input id="eduDegree" placeholder="Degree" size="20">
+    <input id="eduDates" placeholder="Dates" size="15">
+    <button onclick="addEducation()">Add</button>
+    <ul id="educationList"></ul>
 </div>
 
 <div>


### PR DESCRIPTION
## Summary
- allow entering name, email, phone, website, and GitHub details
- support adding education entries and selecting them per resume
- include contact info and education in generated LaTeX

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b894474068832f98905339b454c07c